### PR TITLE
Add a nih_threadsafe()

### DIFF
--- a/nih/error.c
+++ b/nih/error.c
@@ -419,3 +419,18 @@ nih_error_pop_context (void)
 	nih_list_remove (&context->entry);
 	nih_free (context);
 }
+
+/**
+ * nih_threadsafe:
+ *
+ * return true if libnih was built to be thread-safe.
+ **/
+int
+nih_threadsafe (void)
+{
+#if defined(__thread)
+	return 0;
+#else
+	return 1;
+#endif
+}

--- a/nih/error.h
+++ b/nih/error.h
@@ -288,6 +288,8 @@ NihError *nih_error_steal         (void)
 void      nih_error_push_context  (void);
 void      nih_error_pop_context   (void);
 
+int       nih_threadsafe          (void);
+
 NIH_END_EXTERN
 
 #endif /* NIH_ERROR_H */


### PR DESCRIPTION
If libnih is built without --enable-threading, then it is not
safe for threaded applications to use it (un-mutexed).  For
instance two competing threads could try to report a nih_error
at the same time and cause a crash.

So that applications can know whether they can use threads,
provide a helper function, nih_threadsafe(), which returns 1
if threads are safe.  (In configure.ac this is done by doing
pound-define __thread to nothing when not threadsafe, and not
pound-defining __thread otherwise).

nih/error.h may not be the best place for this, but no file
seemed particularly suitable, and error handling is where
non-threadsafeness most often shows up so it seemed a reasonable
choice for a first patch.  Better suggestions are welcome.

Signed-off-by: Serge Hallyn serge.hallyn@ubuntu.com
