### PR TITLE
nih/signal.c: only support SIGCLD if it has libc support

### DIFF
--- a/nih/signal.c
+++ b/nih/signal.c
@@ -87,7 +87,9 @@ static const SignalName signal_names[] = {
 	{ SIGSTKFLT, "STKFLT" },
 #endif
 	{ SIGCHLD,   "CHLD"   },
+#ifdef SIGCLD
 	{ SIGCLD,    "CLD"    },
+#endif
 	{ SIGCONT,   "CONT"   },
 	{ SIGSTOP,   "STOP"   },
 	{ SIGTSTP,   "TSTP"   },


### PR DESCRIPTION
Enables support for musl libc. A similar patch which maps CLD to CHLD is used in Void Linux.