### PR TITLE
nih/io.[ch]: remove references to nih_io_close()

### DIFF
--- a/nih/io.c
+++ b/nih/io.c
@@ -1242,7 +1242,7 @@ nih_io_closed (NihIo *io)
  *
  * Marks the NihIo structure to be closed once the buffers or queue have
  * been emptied, rather than immediately.  Closure is performed by calling
- * the close handler if given or nih_io_close().
+ * the close handler if given or nih_io_destroy().
  *
  * This is most useful to send a burst of data and discard the structure
  * once the data has been sent, without worrying about keeping track of

--- a/nih/io.h
+++ b/nih/io.h
@@ -90,10 +90,10 @@ typedef void (*NihIoWatcher) (void *data, NihIoWatch *watch,
  * this message from the queue, otherwise when a new message arrives, the
  * function will still be called with the same oldest message.
  *
- * It is safe to call nih_io_close() from within the reader function, this
+ * It is safe to call nih_io_destroy() from within the reader function, this
  * results in the structure being flagged to be closed when the watcher
  * that invokes it has finished.  You must not nih_free() @io or cause it
- * to be freed from within this function, except by nih_io_close().
+ * to be freed from within this function, except by nih_io_destroy().
  **/
 typedef void (*NihIoReader) (void *data, NihIo *io,
 			     const char *buf, size_t len);
@@ -108,8 +108,8 @@ typedef void (*NihIoReader) (void *data, NihIo *io,
  * read from it.
  *
  * It should take appropriate action, which may include closing the
- * file descriptor with nih_io_close().  You must not nih_free() @io or
- * cause it to be freed from within this function, except by nih_io_close().
+ * file descriptor with nih_io_destroy().  You must not nih_free() @io or
+ * cause it to be freed from within this function, except by nih_io_destroy().
  **/
 typedef void (*NihIoCloseHandler) (void *data, NihIo *io);
 
@@ -123,8 +123,8 @@ typedef void (*NihIoCloseHandler) (void *data, NihIo *io);
  * itself can be obtained using nih_error_get().
  *
  * It should take appropriate action, which may include closing the
- * file descriptor with nih_io_close().  You must not nih_free() @io or
- * cause it to be freed from within this function, except by nih_io_close().
+ * file descriptor with nih_io_destroy().  You must not nih_free() @io or
+ * cause it to be freed from within this function, except by nih_io_destroy().
  **/
 typedef void (*NihIoErrorHandler) (void *data, NihIo *io);
 


### PR DESCRIPTION
This function was renamed to nih_io_destroy() in
commit 72b7f5038c2513e3bdf6b05571fc2180796cccf0.

Signed-off-by: Cameron Nemo <camerontnorman@gmail.com>